### PR TITLE
Fix Babel6 compatibility issue + Added != operator

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -7,7 +7,7 @@ const arithmeticOperators = {
   '*': 'multiply',
 };
 
-const compareOperators = ['===', '==', '>', '<', '>=', '<='];
+const compareOperators = ['===', '==', '>', '<', '>=', '<=', '!=', '!=='];
 
 export default function transformCurrencyOperators({ types: t }) {
   function expressionCallsCurrency(node, identifiers) {

--- a/src/index.js
+++ b/src/index.js
@@ -179,7 +179,8 @@ export default function transformCurrencyOperators({ types: t }) {
           // Prevent replacement nodes from being visited multiple times
           path.stop();
 
-          return path.replaceWith(buildExpression(path, opts.methodName));
+          path.replaceWith(buildExpression(path, opts.methodName));
+          return;
         }
 
         return;

--- a/test/index.js
+++ b/test/index.js
@@ -88,6 +88,17 @@ pluginTester({
       `,
     },
     {
+      title: 'compare currencies different from transform',
+      code: `
+        import currency from 'currency.js';
+        if (currency(1.23) != currency(4.56)) {}
+      `,
+      output: `
+        import currency from 'currency.js';
+        if (currency(1.23).value != currency(4.56).value) {}
+      `,
+    },
+    {
       title: 'compare currencies less than transform',
       code: `
         import currency from 'currency.js';


### PR DESCRIPTION
This PR fixes a compatibility issue with Babel6 that caused the build script on projects using this plugin to throw the following error:

> Error: Unexpected return value from visitor method function: newFn

This is caused because Babel6 does not allow visitor functions to return truthy values.


Also it adds the `!=` and `!==` operators.